### PR TITLE
Remove mbed-mesh-api dependency

### DIFF
--- a/module.json
+++ b/module.json
@@ -25,7 +25,7 @@
       "sal-stack-lwip": "~0.4.0"
     },
     "/mbed-os/net/stacks/nanostack": {
-      "mbed-mesh-api": "<1.0.0"
+      "mbed-mesh-api": "~0.3.0"
     },
     "picotcp": {
       "mbed-net-picotcp-wrapper": "ARMmbed/mbed-net-picotcp-wrapper"

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "sal",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "C Socket abstraction layer",
   "keywords": [],
   "author": "Brendan Moran <brendan.moran@arm.com>",

--- a/module.json
+++ b/module.json
@@ -24,8 +24,8 @@
     "/mbed-os/net/stacks/lwip": {
       "sal-stack-lwip": "~0.4.0"
     },
-    "nanostack": {
-      "mbed-mesh-api": "~0.0.1"
+    "/mbed-os/net/stacks/nanostack": {
+      "mbed-mesh-api": "<1.0.0"
     },
     "picotcp": {
       "mbed-net-picotcp-wrapper": "ARMmbed/mbed-net-picotcp-wrapper"


### PR DESCRIPTION
mbed-mesh-api removed because of issue:
https://github.com/ARMmbed/mbed-net-socket-abstract/issues/14

@bremoran would you please review the change?