### PR TITLE
Add a socket_set_options and socket_get_options API.

### DIFF
--- a/mbed-net-socket-abstract/socket_api.h
+++ b/mbed-net-socket-abstract/socket_api.h
@@ -1,5 +1,5 @@
 /*
- * PackageLicenseDeclared: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) 2015 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,10 @@
 extern "C" {
 #endif
 
+#ifdef YOTTA_CFG_MBED_OS_NET_STACKS_MAX
+#define SOCKET_MAX_STACKS YOTTA_CFG_MBED_OS_NET_STACKS_MAX
+#endif
+
 #ifndef SOCKET_MAX_STACKS
 #define SOCKET_MAX_STACKS 2
 #endif
@@ -44,10 +48,15 @@ typedef socket_error_t (*socket_stop_listen)(struct socket *socket);
 typedef socket_error_t (*socket_accept)(struct socket *sock, socket_api_handler_t handler);
 typedef socket_error_t (*socket_reject)(struct socket *sock);
 typedef socket_error_t (*socket_send)(struct socket *socket, const void * buf, const size_t len);
-typedef socket_error_t (*socket_send_to)(struct socket *socket, const void * buf, const size_t len, const struct socket_addr *addr, const uint16_t port);
+typedef socket_error_t (*socket_send_to)(struct socket *socket, const void * buf, const size_t len,
+        const struct socket_addr *addr, const uint16_t port);
 typedef socket_error_t (*socket_recv)(struct socket *socket, void * buf, size_t *len);
-typedef socket_error_t (*socket_recv_from)(struct socket *socket, void * buf, size_t *len, struct socket_addr *addr, uint16_t *port);
-
+typedef socket_error_t (*socket_recv_from)(struct socket *socket, void * buf, size_t *len, struct socket_addr *addr,
+        uint16_t *port);
+typedef socket_error_t (*socket_set_option)(struct socket *socket, const socket_proto_level_t level,
+        const socket_option_type_t type, const void *option, const size_t optionSize);
+typedef socket_error_t (*socket_get_option)(struct socket *socket, const socket_proto_level_t level,
+        const socket_option_type_t type, void *option, const size_t optionSize);
 typedef socket_error_t (*socket_get_local_addr)(const struct socket *socket, struct socket_addr *addr);
 typedef socket_error_t (*socket_get_remote_addr)(const struct socket *socket, struct socket_addr *addr);
 typedef socket_error_t (*socket_get_local_port)(const struct socket *socket, uint16_t *port);
@@ -77,6 +86,8 @@ struct socket_api {
     socket_send_to              send_to;
     socket_recv                 recv;
     socket_recv_from            recv_from;
+    socket_set_option           set_option;
+    socket_get_option           get_option;
     socket_is_connected         is_connected;
     socket_is_bound             is_bound;
     socket_get_local_addr       get_local_addr;

--- a/mbed-net-socket-abstract/socket_types.h
+++ b/mbed-net-socket-abstract/socket_types.h
@@ -115,6 +115,28 @@ typedef enum {
     SOCKET_BUFFER_NANOSTACK_PBUF,
 } socket_buffer_type_t;
 
+typedef enum {
+    SOCKET_OPT_UNINIT = 0,
+    SOCKET_OPT_NAGGLE,
+    SOCKET_OPT_KEEPALIVE,
+    SOCKET_OPT_MAX
+} socket_option_type_t;
+
+typedef enum {
+    SOCKET_PROTO_LEVEL_UNINIT = 0,
+    SOCKET_PROTO_LEVEL_RAW,
+    SOCKET_PROTO_LEVEL_ICMP,
+    SOCKET_PROTO_LEVEL_ICMP6,
+    SOCKET_PROTO_LEVEL_IGMP,
+    SOCKET_PROTO_LEVEL_IGMP6,
+    SOCKET_PROTO_LEVEL_IP,
+    SOCKET_PROTO_LEVEL_IPV6,
+    SOCKET_PROTO_LEVEL_TCP,
+    SOCKET_PROTO_LEVEL_UDP,
+    SOCKET_PROTO_LEVEL_SOCK,
+    SOCKET_PROTO_LEVEL_MAX
+} socket_proto_level_t;
+
 struct socket_addr {
     uint32_t ipv6be[4];
 };


### PR DESCRIPTION
The individual option enums and structures are not populated.  These will be added on an as-needed basis.  Early candidates are naggle, tcp keepalive.