### PR TITLE
Add a yotta config dependency for nanostack

### DIFF
--- a/module.json
+++ b/module.json
@@ -27,6 +27,9 @@
     "nanostack": {
       "mbed-mesh-api": "~0.0.1"
     },
+    "/mbed-os/net/stacks/nanostack": {
+      "mbed-mesh-api": "~0.0.1"
+    },
     "picotcp": {
       "mbed-net-picotcp-wrapper": "ARMmbed/mbed-net-picotcp-wrapper"
     }

--- a/module.json
+++ b/module.json
@@ -29,9 +29,6 @@
     },
     "/mbed-os/net/stacks/nanostack": {
       "mbed-mesh-api": "~0.0.1"
-    },
-    "picotcp": {
-      "mbed-net-picotcp-wrapper": "ARMmbed/mbed-net-picotcp-wrapper"
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -28,7 +28,7 @@
       "mbed-mesh-api": "~0.0.1"
     },
     "/mbed-os/net/stacks/nanostack": {
-      "mbed-mesh-api": "~0.0.1"
+      "mbed-mesh-api": "~0.3.6"
     }
   }
 }


### PR DESCRIPTION
This is a backwards-compatible change for selectively importing nanostack.  Nanostack can be imported into SAL by specifying the following config in either target.json or the application's config.json:

```JSON
"mbed-os" : {
  "net" : {
    "stacks" : {
      "nanostack" : true
    }
  }
}
```

If nanostack has additional configuration, it can be specified in a dictionary instead of "true." This allows users to select nanostack or lwip as needed, at application level without specifying dependencies on either.