### PR TITLE
Add missing dependency on cmsis-core

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,7 +13,9 @@
   },
   "homepage": "https://github.com/ARMmbed/mbed-net-socket-abstract",
   "license": "Apache-2",
-  "dependencies": {},
+  "dependencies": {
+      "cmsis-core" : "^1.0.1"
+  },
   "scripts": {
     "testReporter": [
       "mbedgt",


### PR DESCRIPTION
sal uses ```__REV()``` to implement ```htonl()``` if it’s not already defined.  This introduces a potential dependency on cmsis-core.

Potential dependency is caused here: https://github.com/ARMmbed/sal/blob/master/sal/socket_api.h#L106

Fixes https://github.com/ARMmbed/sal/issues/23