### PR TITLE
Fix naming error for Nagle option

### DIFF
--- a/sal/socket_types.h
+++ b/sal/socket_types.h
@@ -117,6 +117,7 @@ typedef enum {
 
 typedef enum {
     SOCKET_OPT_UNINIT = 0,
+    SOCKET_OPT_NAGGLE, //Deprecated
     SOCKET_OPT_NAGLE,
     SOCKET_OPT_KEEPALIVE,
     SOCKET_OPT_MAX

--- a/sal/socket_types.h
+++ b/sal/socket_types.h
@@ -122,10 +122,6 @@ typedef enum {
     SOCKET_OPT_MAX
 } socket_option_type_t;
 
-struct socket_nagle_info {
-    uint32_t enable;
-}
-
 typedef enum {
     SOCKET_PROTO_LEVEL_UNINIT = 0,
     SOCKET_PROTO_LEVEL_RAW,

--- a/sal/socket_types.h
+++ b/sal/socket_types.h
@@ -117,10 +117,14 @@ typedef enum {
 
 typedef enum {
     SOCKET_OPT_UNINIT = 0,
-    SOCKET_OPT_NAGGLE,
+    SOCKET_OPT_NAGLE,
     SOCKET_OPT_KEEPALIVE,
     SOCKET_OPT_MAX
 } socket_option_type_t;
+
+struct socket_nagle_info {
+    uint32_t enable;
+}
 
 typedef enum {
     SOCKET_PROTO_LEVEL_UNINIT = 0,


### PR DESCRIPTION
cc @bogdanm @niklas-arm @SeppoTakalo @artokin 

I don't believe that the Nagle option has been used anywhere yet, so this should be safe to rename.

@SeppoTakalo & @artokin can you confirm that Nagle hasn't been used in sal-stack-nanostack?