### PR TITLE
Adapt inet_pton to use a struct socket_addr

### DIFF
--- a/sal/socket_api.h
+++ b/sal/socket_api.h
@@ -115,7 +115,7 @@ typedef	__socklen_t	socklen_t;
 char *
 inet_ntop(int af, const void *src, char *dst, socklen_t size);
 int
-inet_pton(int af, const char *src, void *dst);
+inet_pton(int af, const char *src, struct socket_addr *dst);
 char *
 inet_ntoa(struct socket_addr ina);
 char *

--- a/source/inet_pton.c
+++ b/source/inet_pton.c
@@ -41,13 +41,19 @@ static int	inet_pton6(const char *src, u_char *dst);
  *	Paul Vixie, 1996.
  */
 int
-inet_pton(int af, const char *src, void *dst)
+inet_pton(int af, const char *src, struct socket_addr *dst)
 {
 	switch (af) {
-	case AF_INET:
-		return (inet_pton4(src, dst));
+	case AF_INET: {
+		in_addr_t addr;
+		int rc = inet_pton4(src, (void*)&addr);
+		if (rc == 1) {
+			socket_addr_set_ipv4_addr(dst, addr);
+		}
+		return rc;
+	}
 	case AF_INET6:
-		return (inet_pton6(src, dst));
+		return (inet_pton6(src, (void*)dst->ipv6be));
 	default:
 		return (-1);
 	}


### PR DESCRIPTION
This makes inet_pton more useful in our codebase.

@niklas-arm @adbridge @bogdanm @0xc0170 

Required by https://github.com/ARMmbed/sockets/pull/43