### PR TITLE
Test ported to new utest-greentea framework

### DIFF
--- a/module.json
+++ b/module.json
@@ -27,7 +27,9 @@
   },
   "targetDependencies": {
     "/mbed-os/net/stacks/lwip": {
-      "sal-stack-lwip": "^1.0.0"
+      "sal-stack-lwip": "^1.0.0",
+      "unity": "^2.0.1",
+      "greentea-client": "^0.1.4"
     },
     "/mbed-os/net/stacks/nanostack": {
       "mbed-mesh-api": "^2.0.0"

--- a/test/stack-registry/main.cpp
+++ b/test/stack-registry/main.cpp
@@ -18,31 +18,34 @@
 #include <stdio.h>
 #include <string.h>
 #include "sal/socket_api.h"
-#include "sal/test/ctest_env.h"
-#include "mbed/test_env.h"
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+
+
+using namespace utest::v1;
 
 struct socket_api test_api[SOCKET_MAX_STACKS+1];
 struct socket_api expect_fail_api;
 
 #define SOCKET_ABSTRACTION_LAYER_VERSION 1
 
-int test_socket_stack_registry() {
+control_t test_socket_stack_registry(const size_t) {
     unsigned int i;
     socket_error_t err = SOCKET_ERROR_NONE;
     printf("Testing stack registry...\n");
-    TEST_CLEAR();
 
     // Try to register a stack marked as Uninitialized
     expect_fail_api.stack = SOCKET_STACK_UNINIT;
     expect_fail_api.version = SOCKET_ABSTRACTION_LAYER_VERSION;
     err = socket_register_stack((&expect_fail_api));
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
 
     // Register a NULL socket api
     memset(&expect_fail_api, 0, sizeof(struct socket_api));
     expect_fail_api.version = SOCKET_ABSTRACTION_LAYER_VERSION;
     err = socket_register_stack(&expect_fail_api);
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
 
     // Register a socket api with one zeroed API.
     memset(&expect_fail_api, 1, sizeof(struct socket_api));
@@ -50,14 +53,14 @@ int test_socket_stack_registry() {
     expect_fail_api.create = NULL;
     expect_fail_api.stack = static_cast<socket_stack_t>(SOCKET_STACK_UNINIT + 1);
     err = socket_register_stack(&expect_fail_api);
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
 
     // Register a socket api with the version set wrong
     memset(&expect_fail_api, 1, sizeof(struct socket_api));
     expect_fail_api.version = 0;
     expect_fail_api.stack = static_cast<socket_stack_t>(SOCKET_STACK_UNINIT + 1);
     err = socket_register_stack(&expect_fail_api);
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
 
     // Register two of the same socket api's
     memset(&test_api[0], 1, sizeof(struct socket_api));
@@ -67,23 +70,23 @@ int test_socket_stack_registry() {
     expect_fail_api.stack = static_cast<socket_stack_t>(SOCKET_STACK_UNINIT + 1);
     expect_fail_api.version = SOCKET_ABSTRACTION_LAYER_VERSION;
     err = socket_register_stack(&test_api[0]);
-    TEST_EQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_EQUAL(SOCKET_ERROR_NONE, err);
     err = socket_register_stack(&expect_fail_api);
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
 
     // Register the same stack again, but with the stack ID changed
 
     test_api[0].stack = static_cast<socket_stack_t>(static_cast<uint32_t>(test_api[0].stack) + 1);
     test_api[0].version = SOCKET_ABSTRACTION_LAYER_VERSION;
     err = socket_register_stack(&test_api[0]);
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
     test_api[0].stack = static_cast<socket_stack_t>(static_cast<uint32_t>(test_api[0].stack) - 1);
 
     // Try to register a stack outside the accepted range
     expect_fail_api.stack = SOCKET_STACK_MAX;
     expect_fail_api.version = SOCKET_ABSTRACTION_LAYER_VERSION;
     err = socket_register_stack(&expect_fail_api);
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
 
     // One stack is already registered
     // Try to register the maximum number of stacks
@@ -93,40 +96,54 @@ int test_socket_stack_registry() {
         test_api[i].stack = stack;
         test_api[i].version = SOCKET_ABSTRACTION_LAYER_VERSION;
         err = socket_register_stack(&test_api[i]);
-        TEST_EQ(err,SOCKET_ERROR_NONE);
+        TEST_ASSERT_EQUAL(SOCKET_ERROR_NONE, err);
     }
     // Then register one more.
     expect_fail_api.stack = static_cast<socket_stack_t>(SOCKET_MAX_STACKS + 1);
     expect_fail_api.version = SOCKET_ABSTRACTION_LAYER_VERSION;
     err = socket_register_stack(&expect_fail_api);
-    TEST_NEQ(err,SOCKET_ERROR_NONE);
+    TEST_ASSERT_NOT_EQUAL(SOCKET_ERROR_NONE, err);
 
     // Extract an uninit socket api
     const struct socket_api *papi;
     papi = socket_get_api(SOCKET_STACK_UNINIT);
-    TEST_EQ(papi, NULL);
+    TEST_ASSERT_EQUAL(papi, NULL);
 
     if (SOCKET_MAX_STACKS < SOCKET_STACK_MAX - 1) {
         // Get a valid, but unregistered stack
         papi = socket_get_api(static_cast<socket_stack_t>(SOCKET_STACK_MAX - 1));
-        TEST_EQ(papi, NULL);
+        TEST_ASSERT_EQUAL(papi, NULL);
     }
     // Verify all registered stacks
     for (i = 0; i < SOCKET_MAX_STACKS; i++) {
         socket_stack_t stack = static_cast<socket_stack_t>(SOCKET_STACK_UNINIT + 1 + i);
         papi = socket_get_api(stack);
-        TEST_EQ(papi, &test_api[i]);
+        TEST_ASSERT_EQUAL(papi, &test_api[i]);
     }
 
-    return test_pass_global;
+    return CaseNoRepeat;
 }
 
-void app_start(int, char**) {
-    int rc;
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_TIMEOUT(10);
-    MBED_HOSTTEST_DESCRIPTION(Test the socket stack registry);
-    MBED_HOSTTEST_START("STACK_REGISTRY");
-    rc = test_socket_stack_registry();
-    MBED_HOSTTEST_RESULT(rc);
+const Case cases[] =
+{
+    Case("Test the socket stack registery", test_socket_stack_registry),
+};
+
+status_t greentea_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(10, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
 }
+
+void greentea_teardown(const size_t passed, const size_t failed, const failure_t failure)
+{
+    greentea_test_teardown_handler(passed, failed, failure);
+    GREENTEA_TESTSUITE_RESULT(0 == failed);
+}
+
+const Specification specification(greentea_setup, cases, greentea_teardown);
+
+void app_start(int, char **) {
+    Harness::run(specification);
+}
+


### PR DESCRIPTION
Test ported successfully. Please greentea output below:

```
mbedgt: mbed-host-test-runner: stopped
mbedgt: mbed-host-test-runner: returned 'OK'
mbedgt: test on hardware with target id: 0240022652986e5e000000000000000000000000af4193e6
mbedgt: test suite 'sal-test-stack-registry' ......................................................... OK in 10.09 sec
        test case: 'Test the socket stack registery' ................................................. OK in 0.09 sec
mbedgt: test case summary: 1 pass, 0 failures
mbedgt: shuffle seed: 0.5737960242
mbedgt: test suite report:
+---------------+---------------+-------------------------+--------+--------------------+-------------+
| target        | platform_name | test suite              | result | elapsed_time (sec) | copy_method |
+---------------+---------------+-------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | sal-test-stack-registry | OK     | 10.09              | shell       |
+---------------+---------------+-------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+---------------+---------------+-------------------------+---------------------------------+--------+--------+--------+--------------------+
| target        | platform_name | test suite              | test case                       | passed | failed | result | elapsed_time (sec) |
+---------------+---------------+-------------------------+---------------------------------+--------+--------+--------+--------------------+
| frdm-k64f-gcc | K64F          | sal-test-stack-registry | Test the socket stack registery | 1      | 0      | OK     | 0.09               |
+---------------+---------------+-------------------------+---------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 1 OK
mbedgt: completed in 11.50 sec
```